### PR TITLE
Hotfix for Nginx Config

### DIFF
--- a/etc/nginx/config/default.conf
+++ b/etc/nginx/config/default.conf
@@ -6,7 +6,7 @@ server {
     #access_log  /var/log/nginx/host.access.log  main;
 
     location / {
-        root   /usr/share/nginx/html;
+        root   /var/www/html;
         index  index.html index.htm;
     }
 


### PR DESCRIPTION
Die default config zeigt auf ein falsches Verzeichnis. So kann der User mit dem gemountenten Verzeichnis nichts ändern, da der Webserver die Daten aus einem anderen Verzeichnis anzeigt.